### PR TITLE
Add automated Sunday sermon posting script

### DIFF
--- a/sermon-poster/.github/workflows/post_sermon.yml
+++ b/sermon-poster/.github/workflows/post_sermon.yml
@@ -1,0 +1,28 @@
+name: Post Sunday Sermon
+
+on:
+  schedule:
+    # 10:00 AM EST (UTC-5) = 15:00 UTC / 11:00 AM EDT (UTC-4) = 15:00 UTC
+    - cron: '0 15 * * 0'
+  workflow_dispatch: {}
+
+jobs:
+  post-sermon:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Post sermon to Drupal
+        run: python post_sermon.py
+        env:
+          DRUPAL_BASE_URL: ${{ secrets.DRUPAL_BASE_URL }}
+          DRUPAL_USER: ${{ secrets.DRUPAL_USER }}
+          DRUPAL_PASS: ${{ secrets.DRUPAL_PASS }}

--- a/sermon-poster/CLAUDE.md
+++ b/sermon-poster/CLAUDE.md
@@ -1,0 +1,51 @@
+# Sunday Sermon Auto-Poster
+
+Automatically posts a published sermon node to fbcaurora.in (Drupal 10) every Sunday by pulling the YouTube video URL and sermon details from two sources.
+
+## What it does
+
+1. Fetches the latest video URL from the @fbcaurora YouTube channel via yt-dlp
+2. Scrapes the sermon title (`#message-title`) and scripture reference (`#message-scripture`) from https://imrodmartin.github.io/sunday-message/
+3. Creates a remote video media entity in Drupal via JSON:API
+4. Creates a published `sermons` node with all fields populated
+
+## Running it
+
+Triggered automatically every Sunday via GitHub Actions cron. To run manually:
+
+- GitHub: **Actions → Post Sunday Sermon → Run workflow**
+- Local: set the three env vars below and run `python post_sermon.py`
+
+## Required GitHub Secrets
+
+| Secret | Description |
+|---|---|
+| `DRUPAL_BASE_URL` | `https://fbcaurora.in` |
+| `DRUPAL_USER` | Drupal admin username |
+| `DRUPAL_PASS` | Drupal admin password |
+
+## Schedule
+
+Cron is set to `0 15 * * 0` (15:00 UTC every Sunday):
+- **Winter (EST):** 10:00 AM
+- **Summer (EDT):** 11:00 AM
+
+To change it, edit the `cron` line in `.github/workflows/post_sermon.yml`. Use `0 14 * * 0` for 10:00 AM EDT in summer.
+
+## Drupal field names
+
+Defined as constants at the top of `post_sermon.py` — adjust here if the Drupal site changes:
+
+| Constant | Value | What it maps to |
+|---|---|---|
+| `SPEAKER_VOCAB` | `speaker` | Taxonomy vocabulary machine name |
+| `SPEAKER_TID` | `28` | Term ID for Pastor Bill Secrest |
+| `MEDIA_BUNDLE` | `remote_video` | Media type bundle machine name |
+| `OEMBED_FIELD` | `field_media_oembed_video` | Remote video URL field |
+
+Drupal content type fields used: `title`, `body`, `field_sermon_date`, `field_sermon_video`, `field_speaker`.
+
+## Drupal prerequisite
+
+JSON:API must be set to allow write operations at:
+`https://fbcaurora.in/admin/config/services/jsonapi`

--- a/sermon-poster/post_sermon.py
+++ b/sermon-poster/post_sermon.py
@@ -8,10 +8,10 @@ import yt_dlp
 from bs4 import BeautifulSoup
 
 # Adjust these if your Drupal site uses different machine names
-SPEAKER_VOCAB = "speakers"
+SPEAKER_VOCAB = "speaker"
+SPEAKER_TID = 28
 MEDIA_BUNDLE = "remote_video"
 OEMBED_FIELD = "field_media_oembed_video"
-SPEAKER_NAME = "Pastor Bill Secrest"
 SUNDAY_MESSAGE_URL = "https://imrodmartin.github.io/sunday-message/"
 YOUTUBE_CHANNEL = "https://www.youtube.com/@fbcaurora"
 
@@ -67,18 +67,12 @@ def get_sermon_info() -> tuple[str, str]:
 
 
 def get_speaker_uuid(session: requests.Session, base_url: str, headers: dict) -> str:
-    url = (
-        f"{base_url}/jsonapi/taxonomy_term/{SPEAKER_VOCAB}"
-        f"?filter[name]={requests.utils.quote(SPEAKER_NAME)}"
-    )
+    url = f"{base_url}/jsonapi/taxonomy_term/{SPEAKER_VOCAB}?filter[drupal_internal__tid]={SPEAKER_TID}"
     resp = session.get(url, headers=headers, timeout=30)
     resp.raise_for_status()
     data = resp.json().get("data", [])
     if not data:
-        raise RuntimeError(
-            f"Speaker '{SPEAKER_NAME}' not found in taxonomy '{SPEAKER_VOCAB}'. "
-            "Check SPEAKER_VOCAB constant or the term name in Drupal."
-        )
+        raise RuntimeError(f"Speaker term {SPEAKER_TID} not found in vocabulary '{SPEAKER_VOCAB}'")
     return data[0]["id"]
 
 

--- a/sermon-poster/post_sermon.py
+++ b/sermon-poster/post_sermon.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import time
-from base64 import b64encode
 from datetime import date
 
 import requests
@@ -65,12 +64,6 @@ def get_sermon_info() -> tuple[str, str]:
         raise RuntimeError("Could not find #message-scripture on sunday-message page")
 
     return title_el.get_text(strip=True), scripture_el.get_text(strip=True)
-
-
-def get_csrf_token(session: requests.Session, base_url: str) -> str:
-    resp = session.get(f"{base_url}/session/token", timeout=30)
-    resp.raise_for_status()
-    return resp.text.strip()
 
 
 def get_speaker_uuid(session: requests.Session, base_url: str, headers: dict) -> str:
@@ -174,13 +167,10 @@ def main() -> None:
     print("Finding latest YouTube video...")
     video_url = get_latest_video_url_with_retry()
 
-    print("Getting Drupal CSRF token...")
-    csrf_token = get_csrf_token(session, base_url)
-
+    # Basic auth does not require a CSRF token — that's only for cookie sessions
     write_headers = {
         "Content-Type": "application/vnd.api+json",
         "Accept": "application/vnd.api+json",
-        "X-CSRF-Token": csrf_token,
     }
     read_headers = {"Accept": "application/vnd.api+json"}
 

--- a/sermon-poster/post_sermon.py
+++ b/sermon-poster/post_sermon.py
@@ -1,0 +1,204 @@
+import os
+import sys
+import time
+from base64 import b64encode
+from datetime import date
+
+import requests
+import yt_dlp
+from bs4 import BeautifulSoup
+
+# Adjust these if your Drupal site uses different machine names
+SPEAKER_VOCAB = "speakers"
+MEDIA_BUNDLE = "remote_video"
+OEMBED_FIELD = "field_media_oembed_video"
+SPEAKER_NAME = "Pastor Bill Secrest"
+SUNDAY_MESSAGE_URL = "https://imrodmartin.github.io/sunday-message/"
+YOUTUBE_CHANNEL = "https://www.youtube.com/@fbcaurora"
+
+# Retry settings for YouTube (stream may not be live yet when the job fires)
+MAX_VIDEO_RETRIES = 5
+RETRY_SLEEP_SECONDS = 60
+
+
+def get_latest_video_url() -> str:
+    ydl_opts = {
+        "quiet": True,
+        "extract_flat": True,
+        "playlist_items": "1",
+    }
+    for feed in ("streams", "videos"):
+        try:
+            with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+                info = ydl.extract_info(f"{YOUTUBE_CHANNEL}/{feed}", download=False)
+                if info and info.get("entries"):
+                    video_id = info["entries"][0]["id"]
+                    return f"https://www.youtube.com/watch?v={video_id}"
+        except Exception:
+            pass
+    return ""
+
+
+def get_latest_video_url_with_retry() -> str:
+    for attempt in range(1, MAX_VIDEO_RETRIES + 1):
+        url = get_latest_video_url()
+        if url:
+            print(f"Found video URL: {url}")
+            return url
+        if attempt < MAX_VIDEO_RETRIES:
+            print(f"Video not found (attempt {attempt}/{MAX_VIDEO_RETRIES}), retrying in {RETRY_SLEEP_SECONDS}s...")
+            time.sleep(RETRY_SLEEP_SECONDS)
+    raise RuntimeError(f"Could not find a video on {YOUTUBE_CHANNEL} after {MAX_VIDEO_RETRIES} attempts")
+
+
+def get_sermon_info() -> tuple[str, str]:
+    resp = requests.get(SUNDAY_MESSAGE_URL, timeout=30)
+    resp.raise_for_status()
+    soup = BeautifulSoup(resp.text, "html.parser")
+
+    title_el = soup.find(id="message-title")
+    scripture_el = soup.find(id="message-scripture")
+
+    if not title_el:
+        raise RuntimeError("Could not find #message-title on sunday-message page")
+    if not scripture_el:
+        raise RuntimeError("Could not find #message-scripture on sunday-message page")
+
+    return title_el.get_text(strip=True), scripture_el.get_text(strip=True)
+
+
+def get_csrf_token(session: requests.Session, base_url: str) -> str:
+    resp = session.get(f"{base_url}/session/token", timeout=30)
+    resp.raise_for_status()
+    return resp.text.strip()
+
+
+def get_speaker_uuid(session: requests.Session, base_url: str, headers: dict) -> str:
+    url = (
+        f"{base_url}/jsonapi/taxonomy_term/{SPEAKER_VOCAB}"
+        f"?filter[name]={requests.utils.quote(SPEAKER_NAME)}"
+    )
+    resp = session.get(url, headers=headers, timeout=30)
+    resp.raise_for_status()
+    data = resp.json().get("data", [])
+    if not data:
+        raise RuntimeError(
+            f"Speaker '{SPEAKER_NAME}' not found in taxonomy '{SPEAKER_VOCAB}'. "
+            "Check SPEAKER_VOCAB constant or the term name in Drupal."
+        )
+    return data[0]["id"]
+
+
+def create_media_entity(
+    session: requests.Session, base_url: str, headers: dict, video_url: str, title: str
+) -> str:
+    payload = {
+        "data": {
+            "type": f"media--{MEDIA_BUNDLE}",
+            "attributes": {
+                "name": title,
+                OEMBED_FIELD: video_url,
+            },
+        }
+    }
+    resp = session.post(
+        f"{base_url}/jsonapi/media/{MEDIA_BUNDLE}",
+        json=payload,
+        headers=headers,
+        timeout=30,
+    )
+    if not resp.ok:
+        raise RuntimeError(f"Failed to create media entity ({resp.status_code}): {resp.text}")
+    return resp.json()["data"]["id"]
+
+
+def create_sermon_node(
+    session: requests.Session,
+    base_url: str,
+    headers: dict,
+    title: str,
+    scripture: str,
+    media_uuid: str,
+    speaker_uuid: str,
+) -> str:
+    payload = {
+        "data": {
+            "type": "node--sermons",
+            "attributes": {
+                "title": title,
+                "body": {"value": scripture, "format": "plain_text"},
+                "field_sermon_date": date.today().isoformat(),
+                "status": True,
+            },
+            "relationships": {
+                "field_sermon_video": {
+                    "data": {"type": f"media--{MEDIA_BUNDLE}", "id": media_uuid}
+                },
+                "field_speaker": {
+                    "data": {
+                        "type": f"taxonomy_term--{SPEAKER_VOCAB}",
+                        "id": speaker_uuid,
+                    }
+                },
+            },
+        }
+    }
+    resp = session.post(
+        f"{base_url}/jsonapi/node/sermons",
+        json=payload,
+        headers=headers,
+        timeout=30,
+    )
+    if not resp.ok:
+        raise RuntimeError(f"Failed to create sermon node ({resp.status_code}): {resp.text}")
+    return resp.json()["data"]["id"]
+
+
+def main() -> None:
+    base_url = os.environ.get("DRUPAL_BASE_URL", "").rstrip("/")
+    user = os.environ.get("DRUPAL_USER", "")
+    password = os.environ.get("DRUPAL_PASS", "")
+
+    if not base_url or not user or not password:
+        print("ERROR: DRUPAL_BASE_URL, DRUPAL_USER, and DRUPAL_PASS must all be set.")
+        sys.exit(1)
+
+    session = requests.Session()
+    session.auth = (user, password)
+
+    print("Fetching sermon title and scripture...")
+    title, scripture = get_sermon_info()
+    print(f"  Title: {title}")
+    print(f"  Scripture: {scripture}")
+
+    print("Finding latest YouTube video...")
+    video_url = get_latest_video_url_with_retry()
+
+    print("Getting Drupal CSRF token...")
+    csrf_token = get_csrf_token(session, base_url)
+
+    write_headers = {
+        "Content-Type": "application/vnd.api+json",
+        "Accept": "application/vnd.api+json",
+        "X-CSRF-Token": csrf_token,
+    }
+    read_headers = {"Accept": "application/vnd.api+json"}
+
+    print(f"Looking up speaker UUID for '{SPEAKER_NAME}'...")
+    speaker_uuid = get_speaker_uuid(session, base_url, read_headers)
+    print(f"  Speaker UUID: {speaker_uuid}")
+
+    print("Creating remote video media entity...")
+    media_uuid = create_media_entity(session, base_url, write_headers, video_url, title)
+    print(f"  Media UUID: {media_uuid}")
+
+    print("Creating sermon node...")
+    node_uuid = create_sermon_node(
+        session, base_url, write_headers, title, scripture, media_uuid, speaker_uuid
+    )
+    print(f"  Node UUID: {node_uuid}")
+    print(f"\nDone! Sermon '{title}' published at {base_url}")
+
+
+if __name__ == "__main__":
+    main()

--- a/sermon-poster/requirements.txt
+++ b/sermon-poster/requirements.txt
@@ -1,0 +1,3 @@
+requests
+beautifulsoup4
+yt-dlp


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `sermon-poster/post_sermon.py` — Python script that fetches the latest YouTube video from @fbcaurora, scrapes the sermon title and scripture from https://imrodmartin.github.io/sunday-message/, then creates a published `sermons` node on fbcaurora.in via Drupal 10 JSON:API
- Adds `sermon-poster/requirements.txt` with three dependencies: `requests`, `beautifulsoup4`, `yt-dlp`
- Adds `sermon-poster/.github/workflows/post_sermon.yml` — GitHub Actions workflow triggered by cron every Sunday at 15:00 UTC (10 AM EST / 11 AM EDT) plus `workflow_dispatch` for manual runs

## Deployment (move to private repo)

Because this workflow needs secrets (Drupal credentials), you should host it in a **new private GitHub repo**:

1. Create a private repo (e.g. `fbc-sermon-poster`)
2. Copy the contents of `sermon-poster/` as the root of that repo
3. Add these three **GitHub Secrets** in the repo settings:
   - `DRUPAL_BASE_URL` → `https://fbcaurora.in`
   - `DRUPAL_USER` → your Drupal admin username
   - `DRUPAL_PASS` → your Drupal admin password
4. Use **Actions → Post Sunday Sermon → Run workflow** to do a manual test run before the first Sunday

## Adjustable constants in post_sermon.py

| Constant | Default | Change if… |
|---|---|---|
| `SPEAKER_VOCAB` | `speakers` | taxonomy vocabulary machine name differs |
| `MEDIA_BUNDLE` | `remote_video` | media type bundle name differs |
| `OEMBED_FIELD` | `field_media_oembed_video` | remote video URL field was renamed |

## Test plan

- [ ] Copy `sermon-poster/` contents to a new private repo
- [ ] Add the three GitHub Secrets
- [ ] Trigger manually via `workflow_dispatch` and confirm the job succeeds
- [ ] Visit fbcaurora.in and verify the new sermon node: title, scripture body, embedded video, today's date, Pastor Bill Secrest speaker, published status
- [ ] Wait for the first automatic Sunday run and confirm it fires at 10 AM EST

https://claude.ai/code/session_01USX4fJp7wkEQYnPDjTQfYQ
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01USX4fJp7wkEQYnPDjTQfYQ)_